### PR TITLE
deprecate set-optout command

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,4 +18,4 @@ changelog="${changelog//'%'/'%25'}"
 changelog="${changelog//$'\n'/'%0A' - }"
 changelog=" - ${changelog//$'\r'/'%0D'}"
 
-echo "::set-output name=changelog::$changelog"
+echo "changelog=$changelog" >> $GITHUB_OPTOUT


### PR DESCRIPTION
Per https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ , deprecating set-output command in favor of GITHUB_OUTPUT.